### PR TITLE
react.dev: Compat with React 19 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "@types/mdx-js__react": "^1.5.2",
     "@types/node": "^14.6.4",
     "@types/parse-numeric-range": "^0.0.1",
-    "@types/react": "^18.0.9",
-    "@types/react-dom": "^18.0.5",
+    "@types/react": "npm:types-react@19.0.0",
+    "@types/react-dom": "npm:types-react-dom@19.0.0",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "asyncro": "^3.0.0",
@@ -95,6 +95,11 @@
     "typescript": "^4.0.2",
     "unist-util-visit": "^2.0.3",
     "webpack-bundle-analyzer": "^4.5.0"
+  },
+  "resolutions": {
+    "@types/react": "npm:types-react@19.0.0",
+    "@types/react-dom": "npm:types-react-dom@19.0.0",
+    "@types/react-is": "npm:types-react-is@19.0.0"
   },
   "engines": {
     "node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,3 +1,4 @@
+import type {JSX} from 'react';
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  */

--- a/src/components/Icon/IconArrow.tsx
+++ b/src/components/Icon/IconArrow.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 import cn from 'classnames';
 
 export const IconArrow = memo<

--- a/src/components/Icon/IconArrowSmall.tsx
+++ b/src/components/Icon/IconArrowSmall.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 import cn from 'classnames';
 
 export const IconArrowSmall = memo<

--- a/src/components/Icon/IconCanary.tsx
+++ b/src/components/Icon/IconCanary.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconCanary = memo<JSX.IntrinsicElements['svg'] & {title?: string}>(
   function IconCanary({className, title}) {

--- a/src/components/Icon/IconChevron.tsx
+++ b/src/components/Icon/IconChevron.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 import cn from 'classnames';
 
 export const IconChevron = memo<

--- a/src/components/Icon/IconClose.tsx
+++ b/src/components/Icon/IconClose.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconClose = memo<JSX.IntrinsicElements['svg']>(function IconClose(
   props

--- a/src/components/Icon/IconCodeBlock.tsx
+++ b/src/components/Icon/IconCodeBlock.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconCodeBlock = memo<JSX.IntrinsicElements['svg']>(
   function IconCodeBlock({className}) {

--- a/src/components/Icon/IconCopy.tsx
+++ b/src/components/Icon/IconCopy.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconCopy = memo<JSX.IntrinsicElements['svg']>(function IconCopy({
   className,

--- a/src/components/Icon/IconDeepDive.tsx
+++ b/src/components/Icon/IconDeepDive.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconDeepDive = memo<JSX.IntrinsicElements['svg']>(
   function IconDeepDive({className}) {

--- a/src/components/Icon/IconDownload.tsx
+++ b/src/components/Icon/IconDownload.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconDownload = memo<JSX.IntrinsicElements['svg']>(
   function IconDownload({className}) {

--- a/src/components/Icon/IconError.tsx
+++ b/src/components/Icon/IconError.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconError = memo<JSX.IntrinsicElements['svg']>(function IconError({
   className,

--- a/src/components/Icon/IconFacebookCircle.tsx
+++ b/src/components/Icon/IconFacebookCircle.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconFacebookCircle = memo<JSX.IntrinsicElements['svg']>(
   function IconFacebookCircle(props) {

--- a/src/components/Icon/IconGitHub.tsx
+++ b/src/components/Icon/IconGitHub.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconGitHub = memo<JSX.IntrinsicElements['svg']>(
   function IconGitHub(props) {

--- a/src/components/Icon/IconHamburger.tsx
+++ b/src/components/Icon/IconHamburger.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconHamburger = memo<JSX.IntrinsicElements['svg']>(
   function IconHamburger(props) {

--- a/src/components/Icon/IconHint.tsx
+++ b/src/components/Icon/IconHint.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 import cn from 'classnames';
 
 export const IconHint = memo<JSX.IntrinsicElements['svg']>(function IconHint({

--- a/src/components/Icon/IconInstagram.tsx
+++ b/src/components/Icon/IconInstagram.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconInstagram = memo<JSX.IntrinsicElements['svg']>(
   function IconInstagram(props) {

--- a/src/components/Icon/IconLink.tsx
+++ b/src/components/Icon/IconLink.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconLink = memo<JSX.IntrinsicElements['svg']>(function IconLink(
   props

--- a/src/components/Icon/IconNavArrow.tsx
+++ b/src/components/Icon/IconNavArrow.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 import cn from 'classnames';
 
 export const IconNavArrow = memo<

--- a/src/components/Icon/IconNewPage.tsx
+++ b/src/components/Icon/IconNewPage.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconNewPage = memo<JSX.IntrinsicElements['svg']>(
   function IconNewPage(props) {

--- a/src/components/Icon/IconNote.tsx
+++ b/src/components/Icon/IconNote.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconNote = memo<JSX.IntrinsicElements['svg']>(function IconNote({
   className,

--- a/src/components/Icon/IconPitfall.tsx
+++ b/src/components/Icon/IconPitfall.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconPitfall = memo<JSX.IntrinsicElements['svg']>(
   function IconPitfall({className}) {

--- a/src/components/Icon/IconRestart.tsx
+++ b/src/components/Icon/IconRestart.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconRestart = memo<JSX.IntrinsicElements['svg']>(
   function IconRestart({className}) {

--- a/src/components/Icon/IconRss.tsx
+++ b/src/components/Icon/IconRss.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconRss = memo<JSX.IntrinsicElements['svg']>(function IconRss(
   props

--- a/src/components/Icon/IconSearch.tsx
+++ b/src/components/Icon/IconSearch.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconSearch = memo<JSX.IntrinsicElements['svg']>(
   function IconSearch(props) {

--- a/src/components/Icon/IconSolution.tsx
+++ b/src/components/Icon/IconSolution.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 import cn from 'classnames';
 
 export const IconSolution = memo<JSX.IntrinsicElements['svg']>(

--- a/src/components/Icon/IconTerminal.tsx
+++ b/src/components/Icon/IconTerminal.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconTerminal = memo<JSX.IntrinsicElements['svg']>(
   function IconTerminal({className}) {

--- a/src/components/Icon/IconThreads.tsx
+++ b/src/components/Icon/IconThreads.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconThreads = memo<JSX.IntrinsicElements['svg']>(
   function IconThreads(props) {

--- a/src/components/Icon/IconTwitter.tsx
+++ b/src/components/Icon/IconTwitter.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconTwitter = memo<JSX.IntrinsicElements['svg']>(
   function IconTwitter(props) {

--- a/src/components/Icon/IconWarning.tsx
+++ b/src/components/Icon/IconWarning.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {memo} from 'react';
+import {memo, type JSX} from 'react';
 
 export const IconWarning = memo<JSX.IntrinsicElements['svg']>(
   function IconWarning({className}) {

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,3 +1,4 @@
+import type {JSX} from 'react';
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  */

--- a/src/components/MDX/Challenges/Challenges.tsx
+++ b/src/components/MDX/Challenges/Challenges.tsx
@@ -29,7 +29,7 @@ export interface ChallengeContents {
 }
 
 const parseChallengeContents = (
-  children: React.ReactElement[]
+  children: React.ReactElement<any>[]
 ): ChallengeContents[] => {
   const contents: ChallengeContents[] = [];
 

--- a/src/components/MDX/CodeBlock/CodeBlock.tsx
+++ b/src/components/MDX/CodeBlock/CodeBlock.tsx
@@ -289,7 +289,7 @@ function getSyntaxHighlight(theme: any): HighlightStyle {
 
 function getLineDecorators(
   code: string,
-  meta: string
+  meta: string | undefined
 ): Array<{
   line: number;
   className: string;
@@ -309,7 +309,7 @@ function getLineDecorators(
 
 function getInlineDecorators(
   code: string,
-  meta: string
+  meta: string | undefined
 ): Array<{
   step: number;
   line: number;

--- a/src/components/MDX/ConsoleBlock.tsx
+++ b/src/components/MDX/ConsoleBlock.tsx
@@ -34,7 +34,7 @@ function ConsoleBlock({level = 'error', children}: ConsoleBlockProps) {
   if (typeof children === 'string') {
     message = children;
   } else if (isValidElement(children)) {
-    message = children.props.children;
+    message = (children as React.ReactElement<any>).props.children;
   }
 
   return (

--- a/src/components/MDX/InlineCode.tsx
+++ b/src/components/MDX/InlineCode.tsx
@@ -4,6 +4,8 @@
 
 import cn from 'classnames';
 
+import type {JSX} from 'react';
+
 interface InlineCodeProps {
   isLink?: boolean;
   meta?: string;

--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {Children, useContext, useMemo} from 'react';
+import {Children, useContext, useMemo, type JSX} from 'react';
 import * as React from 'react';
 import cn from 'classnames';
 

--- a/src/components/MDX/Sandpack/LoadingOverlay.tsx
+++ b/src/components/MDX/Sandpack/LoadingOverlay.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, type JSX} from 'react';
 
 import {
   LoadingOverlayState,

--- a/src/components/MDX/Sandpack/createFileMap.ts
+++ b/src/components/MDX/Sandpack/createFileMap.ts
@@ -10,7 +10,10 @@ export const SUPPORTED_FILES = [AppJSPath, StylesCSSPath];
 
 export const createFileMap = (codeSnippets: any) => {
   return codeSnippets.reduce(
-    (result: Record<string, SandpackFile>, codeSnippet: React.ReactElement) => {
+    (
+      result: Record<string, SandpackFile>,
+      codeSnippet: React.ReactElement<any>
+    ) => {
       if (
         (codeSnippet.type as any).mdxName !== 'pre' &&
         codeSnippet.type !== 'pre'

--- a/src/components/MDX/TerminalBlock.tsx
+++ b/src/components/MDX/TerminalBlock.tsx
@@ -31,9 +31,9 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
     message = children;
   } else if (
     isValidElement(children) &&
-    typeof children.props.children === 'string'
+    typeof (children.props as any).children === 'string'
   ) {
-    message = children.props.children;
+    message = (children.props as any).children;
   } else {
     throw Error('Expected TerminalBlock children to be a plain string.');
   }

--- a/src/utils/forwardRefWithAs.tsx
+++ b/src/utils/forwardRefWithAs.tsx
@@ -69,11 +69,6 @@ export interface ComponentWithAs<ComponentType extends As, ComponentProps> {
   ): React.ReactElement | null;
 
   displayName?: string;
-  propTypes?: React.WeakValidationMap<
-    PropsWithAs<ComponentType, ComponentProps>
-  >;
-  contextTypes?: React.ValidationMap<any>;
-  defaultProps?: Partial<PropsWithAs<ComponentType, ComponentProps>>;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,33 +1038,25 @@
   resolved "https://registry.yarnpkg.com/@types/parse-numeric-range/-/parse-numeric-range-0.0.1.tgz#1a807487565a753f486cb3ee4b2145937d49759d"
   integrity sha512-nI3rPGKk8BxedokP2VilnW5JyZHYNjGCUDsAZ2JQgISgDflHNUO0wXMfGYP8CkihrKYDm5tilD52XfGhO/ZFCA==
 
-"@types/prop-types@*":
-  version "15.7.4"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
-  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
-
-"@types/react-dom@^18.0.5":
-  version "18.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
-  integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
+"@types/react-dom@npm:types-react-dom@19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/types-react-dom/-/types-react-dom-19.0.0.tgz#48286ba504ac48e9345cc860f76845344c5a633a"
+  integrity sha512-qtWBYduBCmrgf4wqnTrGttEJJSZ6cTGmzuvmWd/34TJNKz/Pp69Islc1+txHF3nRxSuRvmhxztFXvLyxhp8G2w==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
-  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+"@types/react-is@npm:types-react-is@19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/types-react-is/-/types-react-is-19.0.0.tgz#be08fc086ff3ad1907945f90c061fdc4ab76ee9d"
+  integrity sha512-BVPuDAVbCKew7GP9YEFhHq0HChlrEO+/myr+LzS4f0YyvJ9+yW+xrq1oRLHGnhLR+Bsbylais6qOTdWshIC+zQ==
   dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
+    "@types/react" "*"
 
-"@types/react@^18.0.9":
-  version "18.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.9.tgz#d6712a38bd6cd83469603e7359511126f122e878"
-  integrity sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==
+"@types/react@*", "@types/react@npm:types-react@19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/types-react/-/types-react-19.0.0.tgz#36ac2d736c33a6331ec48d50f347248bf6335741"
+  integrity sha512-4hwzwaxNhdHXNhGJ819IMghtTlc/NcUGHcH1IhIU0WOQLKhzRldCJdTga+CvzTt2ugyLw0IBkhoaOsXssAPeFg==
   dependencies:
-    "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
 


### PR DESCRIPTION
Closes https://github.com/eps1lon/DefinitelyTyped/issues/22

Commits are split into the changes that the codemod covers and changes that need to be done manually.

## Remaining issues

- `@headlessui/react/dist/components/listbox/listbox.d.ts` declares `ListBox`, `ListBox.Option` (and many more it seems) as a forwardRef render function i.e. `(props, ref) => Node` which is almost certainly incorrect (unless they expect people to pass it to `forwardRef` first. This was not caught because previously, structurally `ref` took up the position of legacy context.
